### PR TITLE
Make RackAttackAdmin usable

### DIFF
--- a/app/controllers/rack_attack_admin/application_controller.rb
+++ b/app/controllers/rack_attack_admin/application_controller.rb
@@ -1,5 +1,5 @@
 module RackAttackAdmin
-  class ApplicationController < ::ApplicationController
+  class ApplicationController < ActionController::Base
     skip_authorization_check  if respond_to? :skip_authorization_check
     before_action :require_admin, except: [:current_request]  if method_defined?(:require_admin)
     before_action :toggle_flags
@@ -13,7 +13,7 @@ module RackAttackAdmin
 
     helper_method \
     def is_redis?
-      Rack::Attack.cache.respond.store.to_s.match?(/Redis/)
+      Rack::Attack.cache.store.to_s.match?(/Redis/)
     end
 
     helper_method \

--- a/app/controllers/rack_attack_admin/banned_ips_controller.rb
+++ b/app/controllers/rack_attack_admin/banned_ips_controller.rb
@@ -23,7 +23,7 @@ module RackAttackAdmin
       else
         flash[:alert] = "Failed to add: #{ban.errors.full_messages.join('. ')}"
       end
-      redirect_to root_path
+      redirect_to rack_attack_admin.root_path
     end
   end
 end

--- a/app/controllers/rack_attack_admin/keys_controller.rb
+++ b/app/controllers/rack_attack_admin/keys_controller.rb
@@ -5,7 +5,7 @@ module RackAttackAdmin
       unprefixed_key = Rack::Attack.unprefix_key(orig_key)
       Rack::Attack.cache.delete unprefixed_key
       flash[:success] = "Deleted #{unprefixed_key}"
-      redirect_to root_path
+      redirect_to rack_attack_admin.root_path
     end
   end
 end

--- a/app/controllers/rack_attack_admin/rack_attack_controller.rb
+++ b/app/controllers/rack_attack_admin/rack_attack_controller.rb
@@ -5,8 +5,7 @@ module RackAttackAdmin
     # Web version of lib/tasks/rack_attack_admin_tasks.rake
     def index
       @default_banned_ip = Rack::Attack::BannedIp.new(bantime: '60 m')
-      @counters_h     = Rack::Attack.counters_h.
-        without(*Rack::Attack::BannedIps.keys)
+      @counters_h = Rack::Attack.counters_h.with_indifferent_access.except(*Rack::Attack::BannedIps.keys)
       render
     end
 

--- a/rack_attack_admin.gemspec
+++ b/rack_attack_admin.gemspec
@@ -28,12 +28,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.3.0'
-  spec.add_dependency 'activesupport', ['>= 4.2', '< 5.3']
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'activesupport-duration-human_string', '>= 0.1.1'
   spec.add_dependency 'haml'
   spec.add_dependency 'memoist'
   spec.add_dependency 'rack-attack'
-  spec.add_dependency 'rails',         ['>= 4.2', '< 5.3']
+  spec.add_dependency 'rails', '>= 4.2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Rack Attack Admin isn't usable as it stands right now. This patch makes it work.

Tested with:

- Rails 4.2, 5.0, 5.1 and 5.2
- Redis 3.2 server
- `redis` and `redis-rails` gems